### PR TITLE
Get only public creations.

### DIFF
--- a/CreatubblesAPIClient/Sources/Core/APIClient.swift
+++ b/CreatubblesAPIClient/Sources/Core/APIClient.swift
@@ -278,12 +278,12 @@ public class APIClient: NSObject, CreationUploadServiceDelegate
         return creationsDAO.getCreation(creationId, completion: completion)
     }
     
-    public func getCreations(galleryId: String?, userId: String?, keyword: String?, pagingData: PagingData?, sortOrder: SortOrder?, onlyPublic: Bool?, completion: CreationsClosure?) -> RequestHandler
+    public func getCreations(galleryId: String?, userId: String?, keyword: String?, pagingData: PagingData?, sortOrder: SortOrder?, onlyPublic: Bool? = true, completion: CreationsClosure?) -> RequestHandler
     {
         return creationsDAO.getCreations(galleryId, userId: userId, keyword: keyword, pagingData: pagingData, sortOrder: sortOrder, onlyPublic: onlyPublic, completion: completion)
     }
     
-    public func getCreations(galleryId: String?, userId: String?, keyword: String?, sortOrder: SortOrder?, onlyPublic: Bool?, completion: CreationsBatchClosure?) -> RequestHandler
+    public func getCreations(galleryId: String?, userId: String?, keyword: String?, sortOrder: SortOrder?, onlyPublic: Bool? = true, completion: CreationsBatchClosure?) -> RequestHandler
     {
         return creationsDAO.getCreations(galleryId, userId: userId, keyword: keyword, sortOrder: sortOrder, onlyPublic: onlyPublic, completion: completion)
     }

--- a/CreatubblesAPIClient/Sources/Core/APIClient.swift
+++ b/CreatubblesAPIClient/Sources/Core/APIClient.swift
@@ -278,14 +278,14 @@ public class APIClient: NSObject, CreationUploadServiceDelegate
         return creationsDAO.getCreation(creationId, completion: completion)
     }
     
-    public func getCreations(galleryId: String?, userId: String?, keyword: String?, pagingData: PagingData?, sortOrder: SortOrder?, completion: CreationsClosure?) -> RequestHandler
+    public func getCreations(galleryId: String?, userId: String?, keyword: String?, pagingData: PagingData?, sortOrder: SortOrder?, onlyPublic: Bool?, completion: CreationsClosure?) -> RequestHandler
     {
-        return creationsDAO.getCreations(galleryId, userId: userId, keyword: keyword, pagingData: pagingData, sortOrder: sortOrder, completion: completion)
+        return creationsDAO.getCreations(galleryId, userId: userId, keyword: keyword, pagingData: pagingData, sortOrder: sortOrder, onlyPublic: onlyPublic, completion: completion)
     }
     
-    public func getCreations(galleryId: String?, userId: String?, keyword: String?, sortOrder: SortOrder?, completion: CreationsBatchClosure?) -> RequestHandler
+    public func getCreations(galleryId: String?, userId: String?, keyword: String?, sortOrder: SortOrder?, onlyPublic: Bool?, completion: CreationsBatchClosure?) -> RequestHandler
     {
-        return creationsDAO.getCreations(galleryId, userId: userId, keyword: keyword, sortOrder: sortOrder, completion: completion)
+        return creationsDAO.getCreations(galleryId, userId: userId, keyword: keyword, sortOrder: sortOrder, onlyPublic: onlyPublic, completion: completion)
     }
     
     public func getRecomendedCreationsByUser(userId: String, pagingData: PagingData?, completon: CreationsClosure?) -> RequestHandler

--- a/CreatubblesAPIClient/Sources/Core/APIClient_ObjC.swift
+++ b/CreatubblesAPIClient/Sources/Core/APIClient_ObjC.swift
@@ -154,9 +154,9 @@ extension APIClient
         }
     }
     
-    public func _getCreations(galleryId: String, userId: String?, keyword: String?, pagingData: PagingData?, sortOrder: SortOrder, completion: ((Array<Creation>?, PagingInfo?, NSError?) -> (Void))?)
+    public func _getCreations(galleryId: String, userId: String?, keyword: String?, pagingData: PagingData?, sortOrder: SortOrder, onlyPublic: Bool, completion: ((Array<Creation>?, PagingInfo?, NSError?) -> (Void))?)
     {
-        getCreations(galleryId, userId: userId, keyword: keyword, pagingData: pagingData, sortOrder: sortOrder)
+        getCreations(galleryId, userId: userId, keyword: keyword, pagingData: pagingData, sortOrder: sortOrder, onlyPublic: onlyPublic)
         {
             (creations, pInfo, error) -> (Void) in
             completion?(creations, pInfo, APIClient.errorTypeToNSError(error))
@@ -173,9 +173,9 @@ extension APIClient
     }
     
     //MARK: - Batch fetching
-    public func _getCreations(galleryId: String?, userId: String?, keyword: String?, sortOrder: SortOrder, completion: ((Array<Creation>?, NSError?) -> (Void))?)
+    public func _getCreations(galleryId: String?, userId: String?, keyword: String?, sortOrder: SortOrder, onlyPublic: Bool, completion: ((Array<Creation>?, NSError?) -> (Void))?)
     {
-        getCreations(galleryId, userId: userId, keyword: keyword, sortOrder: sortOrder)
+        getCreations(galleryId, userId: userId, keyword: keyword, sortOrder: sortOrder, onlyPublic: onlyPublic)
         {
             (creations, error) -> (Void) in
             completion?(creations, APIClient.errorTypeToNSError(error))

--- a/CreatubblesAPIClient/Sources/DAO/BatchFetch/CreationsBatchFetcher.swift
+++ b/CreatubblesAPIClient/Sources/DAO/BatchFetch/CreationsBatchFetcher.swift
@@ -31,12 +31,13 @@ class CreationsBatchFetcher: BatchFetcher
 
     private var sort: SortOrder?
     private var keyword: String?
+    private var onlyPublic: Bool?
     
     private var allCreations = Array<Creation>()
     
     private var currentRequest: FetchCreationsRequest
     {
-        return FetchCreationsRequest(page: page, perPage: perPage, galleryId: galleryId, userId: userId, sort: sort, keyword: keyword)
+        return FetchCreationsRequest(page: page, perPage: perPage, galleryId: galleryId, userId: userId, sort: sort, keyword: keyword, onlyPublic: onlyPublic)
     }
     
     private func responseHandler(completion: CreationsBatchClosure?) -> FetchCreationsResponseHandler
@@ -70,12 +71,13 @@ class CreationsBatchFetcher: BatchFetcher
         }
     }
     
-    func fetch(userId: String?, galleryId: String?,keyword: String? ,sort:SortOrder?, completion: CreationsBatchClosure?) -> RequestHandler
+    func fetch(userId: String?, galleryId: String?, keyword: String?, sort:SortOrder?, onlyPublic: Bool?, completion: CreationsBatchClosure?) -> RequestHandler
     {
         self.userId = userId
-        self.sort = sort
-        self.keyword = keyword
         self.galleryId = galleryId
+        self.keyword = keyword
+        self.sort = sort
+        self.onlyPublic = onlyPublic
         return requestSender.send(currentRequest, withResponseHandler: responseHandler(completion))
     }
 }

--- a/CreatubblesAPIClient/Sources/DAO/CreationsDAO.swift
+++ b/CreatubblesAPIClient/Sources/DAO/CreationsDAO.swift
@@ -58,17 +58,17 @@ class CreationsDAO
         return requestSender.send(request, withResponseHandler: handler)
     }
     
-    func getCreations(galleryId: String?, userId: String?, keyword: String? ,pagingData: PagingData?, sortOrder: SortOrder?,completion: CreationsClosure?) -> RequestHandler
+    func getCreations(galleryId: String?, userId: String?, keyword: String?, pagingData: PagingData?, sortOrder: SortOrder?, onlyPublic: Bool?, completion: CreationsClosure?) -> RequestHandler
     {
-        let request = FetchCreationsRequest(page: pagingData?.page, perPage: pagingData?.pageSize, galleryId: galleryId, userId: userId, sort: sortOrder, keyword: keyword)
+        let request = FetchCreationsRequest(page: pagingData?.page, perPage: pagingData?.pageSize, galleryId: galleryId, userId: userId, sort: sortOrder, keyword: keyword, onlyPublic: onlyPublic)
         let handler = FetchCreationsResponseHandler(completion: completion)
         return requestSender.send(request, withResponseHandler: handler)
     }
     
-    func getCreations(galleryId: String?, userId: String?, keyword: String?, sortOrder: SortOrder?, completion: CreationsBatchClosure?) -> RequestHandler
+    func getCreations(galleryId: String?, userId: String?, keyword: String?, sortOrder: SortOrder?, onlyPublic: Bool?, completion: CreationsBatchClosure?) -> RequestHandler
     {
         let fetcher = CreationsBatchFetcher(requestSender: requestSender)
-        return fetcher.fetch(userId, galleryId: galleryId, keyword: keyword, sort: sortOrder, completion: completion)
+        return fetcher.fetch(userId, galleryId: galleryId, keyword: keyword, sort: sortOrder, onlyPublic: onlyPublic, completion: completion)
     }
     
     func editCreation(creationId: String, data: EditCreationData, completion: ErrorClosure?) -> RequestHandler

--- a/CreatubblesAPIClient/Sources/Requests/Creation/FetchCreationsRequest.swift
+++ b/CreatubblesAPIClient/Sources/Requests/Creation/FetchCreationsRequest.swift
@@ -52,12 +52,13 @@ class FetchCreationsRequest: Request
     private let userId: String?
     private let sort: SortOrder?
     private let keyword: String?
+    private let onlyPublic: Bool?
     
     private let creationId: String?
     private let recommendedCreationId: String?
     private let recommendedUserId: String?
     
-    init(page: Int?, perPage: Int?, galleryId: String?, userId: String?, sort: SortOrder?, keyword: String?)
+    init(page: Int?, perPage: Int?, galleryId: String?, userId: String?, sort: SortOrder?, keyword: String?, onlyPublic: Bool?)
     {
         self.page = page
         self.perPage = perPage
@@ -65,6 +66,7 @@ class FetchCreationsRequest: Request
         self.userId = userId
         self.sort = sort
         self.keyword = keyword
+        self.onlyPublic = onlyPublic
         self.creationId = nil
         self.recommendedUserId = nil
         self.recommendedCreationId = nil
@@ -78,6 +80,7 @@ class FetchCreationsRequest: Request
         self.userId = nil
         self.sort = nil
         self.keyword = nil
+        self.onlyPublic = nil
         self.creationId = creationId
         self.recommendedUserId = nil
         self.recommendedCreationId = nil
@@ -91,6 +94,7 @@ class FetchCreationsRequest: Request
         self.userId = nil
         self.sort = nil
         self.keyword = nil
+        self.onlyPublic = nil
         self.creationId = nil
         self.recommendedUserId = nil
         self.recommendedCreationId = recommendedCreationId
@@ -104,6 +108,7 @@ class FetchCreationsRequest: Request
         self.userId = nil
         self.sort = nil
         self.keyword = nil
+        self.onlyPublic = nil
         self.creationId = nil
         self.recommendedUserId = recommendedUserId
         self.recommendedCreationId = nil
@@ -132,6 +137,10 @@ class FetchCreationsRequest: Request
         if let sort = sort
         {
             params["sort"] = Request.sortOrderStringValue(sort)
+        }
+        if let onlyPublic = onlyPublic
+        {
+            params["only_public"] = onlyPublic
         }
         if let keyword = keyword
         {

--- a/CreatubblesAPIClientTests/Spec/Creation/CreationRequestSpec.swift
+++ b/CreatubblesAPIClientTests/Spec/Creation/CreationRequestSpec.swift
@@ -18,14 +18,30 @@ class CreationRequestSpec: QuickSpec
         {
             it("Should have a proper method")
             {
-                let request = FetchCreationsRequest(page: 1, perPage: 10, galleryId: nil, userId: nil, sort: .Recent, keyword: nil)
+                let request = FetchCreationsRequest(page: 1, perPage: 10, galleryId: nil, userId: nil, sort: .Recent, keyword: nil, onlyPublic: true)
                 expect(request.method).to(equal(RequestMethod.GET))
             }
             
             it("Should have a proper endpoint")
             {
-                let request = FetchCreationsRequest(page: 1, perPage: 10, galleryId: nil, userId: nil, sort: .Recent, keyword: nil)
+                let request = FetchCreationsRequest(page: 1, perPage: 10, galleryId: nil, userId: nil, sort: .Recent, keyword: nil, onlyPublic: true)
                 expect(request.endpoint).to(equal("creations"))
+            }
+            
+            it("Should have a proper parameters set")
+            {
+                let testGalleryIdentifier = "TestGalleryIdentifier"
+                let testUserIdentifier = "TestUserIdentifier"
+                let testKeyword = "TestKeyword"
+                let sortType = SortOrder.Recent
+                
+                let request = FetchCreationsRequest(page: 1, perPage: 10, galleryId: testGalleryIdentifier, userId: testUserIdentifier, sort: sortType, keyword: testKeyword, onlyPublic: true)
+                
+                expect(request.parameters["gallery_id"] as? String).to(equal(testGalleryIdentifier))
+                expect(request.parameters["user_id"] as? String).to(equal(testUserIdentifier))
+                expect(request.parameters["search"] as? String).to(equal(testKeyword))
+                expect(request.parameters["sort"] as? String).to(equal(Request.sortOrderStringValue(sortType)))
+                expect(request.parameters["only_public"] as? Bool).to(equal(true))
             }
             
             it("Should have proper endpoint for fetching recommended creations")
@@ -37,52 +53,6 @@ class CreationRequestSpec: QuickSpec
                 expect(creationRequest.endpoint).to(equal("creations/\(identifier)/recommended_creations"))
                 expect(userRequest.endpoint).to(equal("users/\(identifier)/recommended_creations"))
             }
-            
-            it("Should return a correct value for creations after login")
-            {
-                let sender = TestComponentsFactory.requestSender
-                waitUntil(timeout: 10)
-                {
-                    done in
-                    sender.login(TestConfiguration.username, password: TestConfiguration.password)
-                    {
-                        (error: ErrorType?) -> Void in
-                        expect(error).to(beNil())
-                        sender.send(FetchCreationsRequest(page: 1, perPage: 10, galleryId: nil, userId: nil, sort: .Recent, keyword: nil), withResponseHandler: DummyResponseHandler()
-                            {
-                                (response, error) -> Void in
-                                expect(response).notTo(beNil())
-                                expect(error).to(beNil())
-                                sender.logout()
-                                done()
-                            })
-                        
-                    }
-                }
-            }
-            it("Should return a correct value for single creation after login")
-            {
-                
-                let sender = TestComponentsFactory.requestSender
-                waitUntil(timeout: 10)
-                {
-                    done in
-                    sender.login(TestConfiguration.username, password: TestConfiguration.password)
-                    {
-                        (error: ErrorType?) -> Void in
-                        expect(error).to(beNil())
-                    sender.send(FetchCreationsRequest(creationId: "YNzO8Rmv"), withResponseHandler: DummyResponseHandler()
-                        {
-                            (response, error) -> Void in
-                            expect(response).notTo(beNil())
-                            expect(error).to(beNil())
-                            sender.logout()
-                            done()
-                        })
-                    }
-                }
-            }
         }
-        
     }
 }

--- a/CreatubblesAPIClientTests/Spec/Creation/CreationResponseHandlerSpec.swift
+++ b/CreatubblesAPIClientTests/Spec/Creation/CreationResponseHandlerSpec.swift
@@ -20,7 +20,7 @@ class CreationResponseHandlerSpec: QuickSpec
         {
             it("Should return correct value for creations after login")
             {
-                let request = FetchCreationsRequest(page: 1, perPage: 10, galleryId: nil, userId: nil, sort: .Recent, keyword: nil)
+                let request = FetchCreationsRequest(page: 1, perPage: 10, galleryId: nil, userId: nil, sort: .Recent, keyword: nil, onlyPublic: true)
                 let sender =  TestComponentsFactory.requestSender
                 waitUntil(timeout: 10)
                 {


### PR DESCRIPTION
JIRA: no JIRA ticket
- handled "only_public" param for getCreations endpoint
- https://stateoftheart.creatubbles.com/api/#list-creations

Questions:
- what is the best way to force a default value of onlyPublic param to be `true`? Leave it as it is (`..., onlyPublic: Bool?, ...`) or add a default value (`..., onlyPublic: Bool? = true, ...`)
- what is default value on server side (if we do not provide any value on client side)?
