### PR TITLE
Error field in CreationUploadSession and CreationUploadSessionPublicData

### DIFF
--- a/CreatubblesAPIClient/Sources/Core/APIClient.swift
+++ b/CreatubblesAPIClient/Sources/Core/APIClient.swift
@@ -339,6 +339,11 @@ public class APIClient: NSObject, CreationUploadServiceDelegate
         creationUploadService.removeAllUploadSessions()
     }
     
+    public func startUploadSession(sessionId: String)
+    {
+        creationUploadService.startUploadSession(sessionId)
+    }
+    
     //MARK: - Creation flow
     public func newCreation(creationData: NewCreationData, completion: CreationClosure?) -> CreationUploadSessionPublicData
     {

--- a/CreatubblesAPIClient/Sources/CreationUploadSession/CreationUploadService.swift
+++ b/CreatubblesAPIClient/Sources/CreationUploadSession/CreationUploadService.swift
@@ -76,17 +76,34 @@ class CreationUploadService: CreationUploadSessionDelegate
         uploadSessions.forEach({ $0.start(completion) })                
     }
     
+    func startUploadSession(sessionId: String)
+    {
+        guard let session = uploadSessions.filter( {$0.localIdentifier == sessionId }).first
+        else
+        {
+            Logger.log.warning("Cannot find session with identifier \(sessionId) to start")
+            return
+        }
+        
+        session.delegate = self
+        session.start(nil)
+    }
+    
     func removeUploadSession(sessionId: String)
     {
-        if  let session = uploadSessions.filter( {$0.localIdentifier == sessionId }).first,
-            let index = uploadSessions.indexOf(session)
+        guard let session = uploadSessions.filter( {$0.localIdentifier == sessionId }).first,
+              let index = uploadSessions.indexOf(session)
+        else
         {
-            session.delegate = nil
-            session.cancel()
-            uploadSessions.removeAtIndex(index)
-            databaseDAO.removeUploadSession(withIdentifier: sessionId)
-            delegate?.creationUploadService(self, uploadFailed: session, withError: APIClientError.UploadCancelled)
+            Logger.log.warning("Cannot find session with identifier \(sessionId) to remove")
+            return
         }
+        
+        session.delegate = nil
+        session.cancel()
+        uploadSessions.removeAtIndex(index)
+        databaseDAO.removeUploadSession(withIdentifier: sessionId)
+        delegate?.creationUploadService(self, uploadFailed: session, withError: APIClientError.UploadCancelled)
     }
     
     func removeAllUploadSessions()
@@ -96,7 +113,6 @@ class CreationUploadService: CreationUploadSessionDelegate
             $0.delegate = nil
             $0.cancel()
         }
-        
         databaseDAO.removeAllUploadSessions()
         uploadSessions = databaseDAO.fetchAllCreationUploadSessions(requestSender)
     }
@@ -111,7 +127,6 @@ class CreationUploadService: CreationUploadSessionDelegate
         delegate?.creationUploadService(self, newSessionAdded: session)
         return CreationUploadSessionPublicData(creationUploadSession: session)        
     }
-    
     
     //MARK: - CreationUploadSessionDelegate
     func creationUploadSessionChangedState(creationUploadSession: CreationUploadSession)

--- a/CreatubblesAPIClient/Sources/CreationUploadSession/CreationUploadSessionPublicData.swift
+++ b/CreatubblesAPIClient/Sources/CreationUploadSession/CreationUploadSessionPublicData.swift
@@ -14,11 +14,13 @@ public class CreationUploadSessionPublicData: NSObject
     public let identifier: String
     public let creationData: NewCreationData
     public let creation: Creation?
+    public let error: ErrorType?
     
     init(creationUploadSession: CreationUploadSession)
     {
-        self.identifier = creationUploadSession.localIdentifier
+        identifier = creationUploadSession.localIdentifier
         creation = creationUploadSession.creation
         creationData = creationUploadSession.creationData
+        error = creationUploadSession.error
     }
 }


### PR DESCRIPTION
This field is needed to handle errors properly in `UploadProgressViewController` in Explorer App
