### PR TITLE
[CI-153] getCreations refactor

### DIFF
--- a/CreatubblesAPIClient/Sources/Core/APIClient.swift
+++ b/CreatubblesAPIClient/Sources/Core/APIClient.swift
@@ -442,9 +442,9 @@ open class APIClient: NSObject, CreationUploadServiceDelegate
         return creationsDAO.reportCreation(creationIdentifier: creationId, message: message, completion: completion)
     }
     
-    open func getCreations(galleryId: String?, userId: String?, keyword: String?, pagingData: PagingData?, sortOrder: SortOrder?, onlyPublic: Bool, completion: CreationsClosure?) -> RequestHandler
+    open func getCreations(galleryId: String?, userId: String?, keyword: String?, pagingData: PagingData?, sortOrder: SortOrder?, partnerApplicationId: String?, onlyPublic: Bool,  completion: CreationsClosure?) -> RequestHandler
     {
-        return creationsDAO.getCreations(galleryIdentifier: galleryId, userId: userId, keyword: keyword, pagingData: pagingData, sortOrder: sortOrder, onlyPublic: onlyPublic, completion: completion)
+        return creationsDAO.getCreations(galleryIdentifier: galleryId, userId: userId, keyword: keyword, pagingData: pagingData, sortOrder: sortOrder, partnerApplicationId: partnerApplicationId, onlyPublic: onlyPublic, completion: completion)
     }
     
     open func getRecomendedCreationsByUser(userId: String, pagingData: PagingData?, completon: CreationsClosure?) -> RequestHandler
@@ -457,21 +457,15 @@ open class APIClient: NSObject, CreationUploadServiceDelegate
         return creationsDAO.getRecomendedCreationsByCreation(creationIdentifier: creationId, pagingData: pagingData, completon: completon)
     }
     
-    open func getCreationsByPartnerApplication(partnerApplicationId: String, pagingData: PagingData?, completion: CreationsClosure?) -> RequestHandler
-    {
-        return creationsDAO.getCreationsByPartnerApplication(partnerApplicationId: partnerApplicationId, pagingData: pagingData, completion: completion)
-    }
-    
     open func editCreation(creationId: String, data: EditCreationData, completion: ErrorClosure?) -> RequestHandler
     {
         return creationsDAO.editCreation(creationIdentifier: creationId, data: data, completion: completion)
     }
     
-    open func getCreationsInBatchMode(galleryId: String?, userId: String?, keyword: String?, sortOrder: SortOrder?, onlyPublic: Bool, completion: CreationsBatchClosure?) -> RequestHandler
+    open func getCreationsInBatchMode(galleryId: String?, userId: String?, keyword: String?, partnerApplicationId: String?, sortOrder: SortOrder?, onlyPublic: Bool, completion: CreationsBatchClosure?) -> RequestHandler
     {
-        return creationsDAO.getCreationsInBatchMode(galleryIdentifier: galleryId, userId: userId, keyword: keyword, sortOrder: sortOrder, onlyPublic: onlyPublic, completion: completion)
+        return creationsDAO.getCreationsInBatchMode(galleryIdentifier: galleryId, userId: userId, keyword: keyword, sortOrder: sortOrder, partnerApplicationId: partnerApplicationId, onlyPublic: onlyPublic, completion: completion)
     }
-    
 
     open func removeCreation(creationId: String, completion: ErrorClosure?) -> RequestHandler
     {

--- a/CreatubblesAPIClient/Sources/Core/APIClient_ObjC.swift
+++ b/CreatubblesAPIClient/Sources/Core/APIClient_ObjC.swift
@@ -375,9 +375,9 @@ extension APIClient
         }
     }
     
-    public func _getCreations(_ galleryId: String, userId: String?, keyword: String?, pagingData: PagingData?, sortOrder: SortOrder, onlyPublic: Bool, completion: ((Array<Creation>?, PagingInfo?, NSError?) -> (Void))?) -> RequestHandler
+    public func _getCreations(_ galleryId: String, userId: String?, keyword: String?, pagingData: PagingData?, sortOrder: SortOrder, partnerApplicationId: String?, onlyPublic: Bool, completion: ((Array<Creation>?, PagingInfo?, NSError?) -> (Void))?) -> RequestHandler
     {
-        return getCreations(galleryId: galleryId, userId: userId, keyword: keyword, pagingData: pagingData, sortOrder: sortOrder, onlyPublic: onlyPublic)
+        return getCreations(galleryId: galleryId, userId: userId, keyword: keyword, pagingData: pagingData, sortOrder: sortOrder, partnerApplicationId: partnerApplicationId, onlyPublic: onlyPublic)
         {
             (creations, pInfo, error) -> (Void) in
             (completion?(creations, pInfo, APIClient.errorTypeToNSError(error)))!
@@ -419,15 +419,6 @@ extension APIClient
             completion?(creations, pInfo, APIClient.errorTypeToNSError(error))
         }
     }
-    
-    public func _getCreationsByPartnerApplication(partnerApplicationId: String, pagingData: PagingData?, completion: ((Array<Creation>?, PagingInfo?, NSError?) -> (Void))?) -> RequestHandler
-    {
-        return getCreationsByPartnerApplication(partnerApplicationId: partnerApplicationId, pagingData: pagingData)
-        {
-            (creations, pInfo, error) -> (Void) in
-            completion?(creations, pInfo, APIClient.errorTypeToNSError(error))
-        }
-    }
 
     public func _editCreation(creationId: String, data: EditCreationData, completion: ((NSError?) -> (Void))?) -> RequestHandler
     {
@@ -449,9 +440,9 @@ extension APIClient
     }
     
     //MARK: - Batch fetching
-    public func _getCreationsInBatchMode(_ galleryId: String?, userId: String?, keyword: String?, sortOrder: SortOrder, onlyPublic: Bool, completion: ((Array<Creation>?, NSError?) -> (Void))?) -> RequestHandler
+    public func _getCreationsInBatchMode(_ galleryId: String?, userId: String?, keyword: String?, partnerApplicationId: String?, sortOrder: SortOrder, onlyPublic: Bool, completion: ((Array<Creation>?, NSError?) -> (Void))?) -> RequestHandler
     {
-        return getCreationsInBatchMode(galleryId: galleryId, userId: userId, keyword: keyword, sortOrder: sortOrder, onlyPublic: onlyPublic)
+        return getCreationsInBatchMode(galleryId: galleryId, userId: userId, keyword: keyword, partnerApplicationId: partnerApplicationId, sortOrder: sortOrder, onlyPublic: onlyPublic)
         {
             (creations, error) -> (Void) in
             (completion?(creations, APIClient.errorTypeToNSError(error)))!

--- a/CreatubblesAPIClient/Sources/DAO/BatchFetch/CreationsBatchFetcher.swift
+++ b/CreatubblesAPIClient/Sources/DAO/BatchFetch/CreationsBatchFetcher.swift
@@ -31,13 +31,14 @@ class CreationsBatchFetcher: BatchFetcher
 
     fileprivate var sort: SortOrder?
     fileprivate var keyword: String?
+    fileprivate var partnerApplicationId: String?
     fileprivate var onlyPublic: Bool = true
     
     fileprivate var allCreations = Array<Creation>()
     
     fileprivate var currentRequest: FetchCreationsRequest
     {
-        return FetchCreationsRequest(page: page, perPage: perPage, galleryId: galleryId, userId: userId, sort: sort, keyword: keyword, onlyPublic: onlyPublic)
+        return FetchCreationsRequest(page: page, perPage: perPage, galleryId: galleryId, userId: userId, sort: sort, keyword: keyword, partnerApplicationId: partnerApplicationId, onlyPublic: onlyPublic)
     }
     
     fileprivate func responseHandler(_ completion: CreationsBatchClosure?) -> FetchCreationsResponseHandler
@@ -71,12 +72,13 @@ class CreationsBatchFetcher: BatchFetcher
         }
     }
     
-    func fetch(_ userId: String?, galleryId: String?, keyword: String?, sort:SortOrder?, onlyPublic: Bool, completion: CreationsBatchClosure?) -> RequestHandler
+    func fetch(_ userId: String?, galleryId: String?, keyword: String?, partnerApplicationId: String?, sort:SortOrder?, onlyPublic: Bool, completion: CreationsBatchClosure?) -> RequestHandler
     {
         self.userId = userId
         self.galleryId = galleryId
         self.keyword = keyword
         self.sort = sort
+        self.partnerApplicationId = partnerApplicationId
         self.onlyPublic = onlyPublic
         return requestSender.send(currentRequest, withResponseHandler: responseHandler(completion))
     }

--- a/CreatubblesAPIClient/Sources/DAO/CreationsDAO.swift
+++ b/CreatubblesAPIClient/Sources/DAO/CreationsDAO.swift
@@ -65,16 +65,9 @@ class CreationsDAO
         return requestSender.send(request, withResponseHandler: handler)
     }
     
-    func getCreationsByPartnerApplication(partnerApplicationId: String, pagingData: PagingData?, completion: CreationsClosure?) -> RequestHandler
+    func getCreations(galleryIdentifier galleryId: String?, userId: String?, keyword: String?, pagingData: PagingData?, sortOrder: SortOrder?, partnerApplicationId: String?, onlyPublic: Bool, completion: CreationsClosure?) -> RequestHandler
     {
-        let request = FetchCreationsRequest(page: pagingData?.page, perPage: pagingData?.pageSize, partnerApplicationId: partnerApplicationId)
-        let handler = FetchCreationsResponseHandler(completion: completion)
-        return requestSender.send(request, withResponseHandler: handler)
-    }
-    
-    func getCreations(galleryIdentifier galleryId: String?, userId: String?, keyword: String?, pagingData: PagingData?, sortOrder: SortOrder?, onlyPublic: Bool, completion: CreationsClosure?) -> RequestHandler
-    {
-        let request = FetchCreationsRequest(page: pagingData?.page, perPage: pagingData?.pageSize, galleryId: galleryId, userId: userId, sort: sortOrder, keyword: keyword, onlyPublic: onlyPublic)
+        let request = FetchCreationsRequest(page: pagingData?.page, perPage: pagingData?.pageSize, galleryId: galleryId, userId: userId, sort: sortOrder, keyword: keyword, partnerApplicationId: partnerApplicationId, onlyPublic: onlyPublic)
         let handler = FetchCreationsResponseHandler(completion: completion)
         return requestSender.send(request, withResponseHandler: handler)
     }
@@ -102,9 +95,9 @@ class CreationsDAO
     }
     
     //MARK: BatchMode
-    func getCreationsInBatchMode(galleryIdentifier galleryId: String?, userId: String?, keyword: String?, sortOrder: SortOrder?, onlyPublic: Bool, completion: CreationsBatchClosure?) -> RequestHandler
+    func getCreationsInBatchMode(galleryIdentifier galleryId: String?, userId: String?, keyword: String?, sortOrder: SortOrder?, partnerApplicationId: String?, onlyPublic: Bool, completion: CreationsBatchClosure?) -> RequestHandler
     {
         let fetcher = CreationsBatchFetcher(requestSender: requestSender)
-        return fetcher.fetch(userId, galleryId: galleryId, keyword: keyword, sort: sortOrder, onlyPublic: onlyPublic, completion: completion)
+        return fetcher.fetch(userId, galleryId: galleryId, keyword: keyword, partnerApplicationId: partnerApplicationId, sort: sortOrder, onlyPublic: onlyPublic, completion: completion)
     }
 }

--- a/CreatubblesAPIClient/Sources/Requests/Creation/FetchCreationsRequest.swift
+++ b/CreatubblesAPIClient/Sources/Requests/Creation/FetchCreationsRequest.swift
@@ -60,7 +60,7 @@ class FetchCreationsRequest: Request
     fileprivate let recommendedUserId: String?
     fileprivate let partnerApplicationId: String?
     
-    init(page: Int?, perPage: Int?, galleryId: String?, userId: String?, sort: SortOrder?, keyword: String?, onlyPublic: Bool)
+    init(page: Int?, perPage: Int?, galleryId: String?, userId: String?, sort: SortOrder?, keyword: String?, partnerApplicationId: String?, onlyPublic: Bool)
     {
         self.page = page
         self.perPage = perPage
@@ -72,7 +72,7 @@ class FetchCreationsRequest: Request
         self.creationId = nil
         self.recommendedUserId = nil
         self.recommendedCreationId = nil
-        self.partnerApplicationId = nil
+        self.partnerApplicationId = partnerApplicationId
     }
     
     init(creationId: String)
@@ -118,21 +118,6 @@ class FetchCreationsRequest: Request
         self.recommendedUserId = recommendedUserId
         self.recommendedCreationId = nil
         self.partnerApplicationId = nil
-    }
-    
-    init(page: Int?, perPage: Int?, partnerApplicationId: String)
-    {
-        self.page = page
-        self.perPage = perPage
-        self.galleryId = nil
-        self.userId = nil
-        self.sort = nil
-        self.keyword = nil
-        self.onlyPublic = true
-        self.creationId = nil
-        self.recommendedUserId = nil
-        self.recommendedCreationId = nil
-        self.partnerApplicationId = partnerApplicationId
     }
     
     func prepareParametersDictionary() -> Dictionary<String, AnyObject>

--- a/CreatubblesAPIClient/Sources/Requests/Creation/FetchCreationsRequest.swift
+++ b/CreatubblesAPIClient/Sources/Requests/Creation/FetchCreationsRequest.swift
@@ -60,7 +60,7 @@ class FetchCreationsRequest: Request
     fileprivate let recommendedUserId: String?
     fileprivate let partnerApplicationId: String?
     
-    init(page: Int?, perPage: Int?, galleryId: String?, userId: String?, sort: SortOrder?, keyword: String?, partnerApplicationId: String?, onlyPublic: Bool)
+    init(page: Int?, perPage: Int?, galleryId: String?, userId: String?, sort: SortOrder?, keyword: String?, partnerApplicationId: String? = nil, onlyPublic: Bool)
     {
         self.page = page
         self.perPage = perPage

--- a/CreatubblesAPIClientTests/Spec/Creation/CreationResponseHandlerSpec.swift
+++ b/CreatubblesAPIClientTests/Spec/Creation/CreationResponseHandlerSpec.swift
@@ -102,7 +102,7 @@ class CreationResponseHandlerSpec: QuickSpec
                 let partnerApplicationId = TestConfiguration.partnerApplicationId
                 else { return }
                 
-                let request = FetchCreationsRequest(page: 1, perPage: 10, partnerApplicationId: partnerApplicationId)
+                let request = FetchCreationsRequest(page: 1, perPage: 10, galleryId: nil, userId: nil, sort: .recent, keyword: nil, partnerApplicationId: partnerApplicationId, onlyPublic: true)
                 let sender =  TestComponentsFactory.requestSender
                 waitUntil(timeout: 10)
                 {


### PR DESCRIPTION
jira: https://nomtek.atlassian.net/browse/CI-153

Removed the `getCreationsByPartnerApplication` method - to fetch creations by PartnerApp an optional parameter `partnerApplicationId` was added to `getCreations` method.