### PR TITLE
[CRI-682] Submit to multiple galleries

### DIFF
--- a/CreatubblesAPIClient.xcodeproj/project.pbxproj
+++ b/CreatubblesAPIClient.xcodeproj/project.pbxproj
@@ -160,6 +160,8 @@
 		1867829A1DE3AA4100823875 /* Migration_Guide_0.2.0.md in Sources */ = {isa = PBXBuildFile; fileRef = 186782951DE3AA4100823875 /* Migration_Guide_0.2.0.md */; };
 		1867829B1DE3AA4100823875 /* Quickstart_ObjectiveC.md in Sources */ = {isa = PBXBuildFile; fileRef = 186782961DE3AA4100823875 /* Quickstart_ObjectiveC.md */; };
 		1867829C1DE3AA4100823875 /* Quickstart_Swift.md in Sources */ = {isa = PBXBuildFile; fileRef = 186782971DE3AA4100823875 /* Quickstart_Swift.md */; };
+		187110F11DFAD65D00F730CE /* GallerySubmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187110F01DFAD65D00F730CE /* GallerySubmitter.swift */; };
+		187110F31DFAD66A00F730CE /* GallerySubmitOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187110F21DFAD66A00F730CE /* GallerySubmitOperation.swift */; };
 		187671431C7CA0F700733E9E /* PagingData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187671421C7CA0F700733E9E /* PagingData.swift */; };
 		187671451C7CA23900733E9E /* NewCreatorData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187671441C7CA23900733E9E /* NewCreatorData.swift */; };
 		187671491C7CA31600733E9E /* NewGalleryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187671481C7CA31600733E9E /* NewGalleryData.swift */; };
@@ -545,6 +547,8 @@
 		186782951DE3AA4100823875 /* Migration_Guide_0.2.0.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = Migration_Guide_0.2.0.md; sourceTree = "<group>"; };
 		186782961DE3AA4100823875 /* Quickstart_ObjectiveC.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = Quickstart_ObjectiveC.md; sourceTree = "<group>"; };
 		186782971DE3AA4100823875 /* Quickstart_Swift.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = Quickstart_Swift.md; sourceTree = "<group>"; };
+		187110F01DFAD65D00F730CE /* GallerySubmitter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GallerySubmitter.swift; sourceTree = "<group>"; };
+		187110F21DFAD66A00F730CE /* GallerySubmitOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GallerySubmitOperation.swift; sourceTree = "<group>"; };
 		187671421C7CA0F700733E9E /* PagingData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingData.swift; sourceTree = "<group>"; };
 		187671441C7CA23900733E9E /* NewCreatorData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewCreatorData.swift; sourceTree = "<group>"; };
 		187671481C7CA31600733E9E /* NewGalleryData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewGalleryData.swift; sourceTree = "<group>"; };
@@ -1063,6 +1067,15 @@
 			path = Documentation;
 			sourceTree = "<group>";
 		};
+		187110EF1DFAD64C00F730CE /* GallerySubmitter */ = {
+			isa = PBXGroup;
+			children = (
+				187110F01DFAD65D00F730CE /* GallerySubmitter.swift */,
+				187110F21DFAD66A00F730CE /* GallerySubmitOperation.swift */,
+			);
+			path = GallerySubmitter;
+			sourceTree = "<group>";
+		};
 		187671411C7CA0DD00733E9E /* Data */ = {
 			isa = PBXGroup;
 			children = (
@@ -1105,6 +1118,7 @@
 			children = (
 				08E52DF61D6C41FB00262672 /* Filters */,
 				21A79F6A1C81E6C5009E95D1 /* BatchFetch */,
+				187110EF1DFAD64C00F730CE /* GallerySubmitter */,
 				1859FA941D3905180023A6B6 /* GroupDAO.swift */,
 				2177451B1DD9C9E60012FFDC /* AvatarDAO.swift */,
 				181E76E31CC5353600A1546A /* BubbleDAO.swift */,
@@ -2022,6 +2036,7 @@
 				08AC6A5D1D424A5F004A35C3 /* ActivitiesDAO.swift in Sources */,
 				212A12221D53582F001BA35A /* PartnerApplicationsSearchRequest.swift in Sources */,
 				18290AF31D070551000EA216 /* NotificationReadRequest.swift in Sources */,
+				187110F31DFAD66A00F730CE /* GallerySubmitOperation.swift in Sources */,
 				18C744FE1C84611600A07E4C /* NewCreationDataEntity.swift in Sources */,
 				212A12151D50DD74001BA35A /* PartnerApplicationRequest.swift in Sources */,
 				18290AF51D07071C000EA216 /* NotificationReadResponseHandler.swift in Sources */,
@@ -2092,6 +2107,7 @@
 				083785931D378B64006EF69E /* ReportUserRequest.swift in Sources */,
 				1814B7781DF83332003B3C65 /* GroupUsersBatchFetchOperation.swift in Sources */,
 				08AC6A641D425439004A35C3 /* ActivityMapper.swift in Sources */,
+				187110F11DFAD65D00F730CE /* GallerySubmitter.swift in Sources */,
 				212A121B1D50EF08001BA35A /* PartnerApplicationsMapper.swift in Sources */,
 				08AC6A661D4259B4004A35C3 /* Activity.swift in Sources */,
 				181E76EC1CC547C000A1546A /* CommentsDAO.swift in Sources */,

--- a/CreatubblesAPIClient.xcodeproj/project.pbxproj
+++ b/CreatubblesAPIClient.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		1867829C1DE3AA4100823875 /* Quickstart_Swift.md in Sources */ = {isa = PBXBuildFile; fileRef = 186782971DE3AA4100823875 /* Quickstart_Swift.md */; };
 		187110F11DFAD65D00F730CE /* GallerySubmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187110F01DFAD65D00F730CE /* GallerySubmitter.swift */; };
 		187110F31DFAD66A00F730CE /* GallerySubmitOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187110F21DFAD66A00F730CE /* GallerySubmitOperation.swift */; };
+		187110F61DFAEF4400F730CE /* GallerySubmitterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187110F51DFAEF4400F730CE /* GallerySubmitterSpec.swift */; };
 		187671431C7CA0F700733E9E /* PagingData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187671421C7CA0F700733E9E /* PagingData.swift */; };
 		187671451C7CA23900733E9E /* NewCreatorData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187671441C7CA23900733E9E /* NewCreatorData.swift */; };
 		187671491C7CA31600733E9E /* NewGalleryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187671481C7CA31600733E9E /* NewGalleryData.swift */; };
@@ -549,6 +550,7 @@
 		186782971DE3AA4100823875 /* Quickstart_Swift.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = Quickstart_Swift.md; sourceTree = "<group>"; };
 		187110F01DFAD65D00F730CE /* GallerySubmitter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GallerySubmitter.swift; sourceTree = "<group>"; };
 		187110F21DFAD66A00F730CE /* GallerySubmitOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GallerySubmitOperation.swift; sourceTree = "<group>"; };
+		187110F51DFAEF4400F730CE /* GallerySubmitterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GallerySubmitterSpec.swift; sourceTree = "<group>"; };
 		187671421C7CA0F700733E9E /* PagingData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingData.swift; sourceTree = "<group>"; };
 		187671441C7CA23900733E9E /* NewCreatorData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewCreatorData.swift; sourceTree = "<group>"; };
 		187671481C7CA31600733E9E /* NewGalleryData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewGalleryData.swift; sourceTree = "<group>"; };
@@ -1076,6 +1078,14 @@
 			path = GallerySubmitter;
 			sourceTree = "<group>";
 		};
+		187110F41DFAEF3B00F730CE /* GallerySubmitter */ = {
+			isa = PBXGroup;
+			children = (
+				187110F51DFAEF4400F730CE /* GallerySubmitterSpec.swift */,
+			);
+			path = GallerySubmitter;
+			sourceTree = "<group>";
+		};
 		187671411C7CA0DD00733E9E /* Data */ = {
 			isa = PBXGroup;
 			children = (
@@ -1285,6 +1295,7 @@
 				18F6E80D1D020F0A00AAC5FB /* Creation */,
 				18F6E8B21D0222D100AAC5FB /* CustomStyle */,
 				18F6E80E1D020F0A00AAC5FB /* Gallery */,
+				187110F41DFAEF3B00F730CE /* GallerySubmitter */,
 				1859FAAD1D39053D0023A6B6 /* Group */,
 				18F6E83E1D02180A00AAC5FB /* LandingURL */,
 				18E435431D0424EB00B728C6 /* Notification */,
@@ -2199,6 +2210,7 @@
 				1814B75B1DF80048003B3C65 /* CreationsBatchFetcherSpec.swift in Sources */,
 				0837859F1D379AAD006EF69E /* ReportGalleryRequestSpec.swift in Sources */,
 				18290AF71D07073F000EA216 /* NotificationReadResponseHandlerSpec.swift in Sources */,
+				187110F61DFAEF4400F730CE /* GallerySubmitterSpec.swift in Sources */,
 				219121961D2D232C0039FA94 /* MyConnectionsResponseHandlerSpec.swift in Sources */,
 				18F6E82D1D0215A400AAC5FB /* NewGalleryResponseHandlerSpec.swift in Sources */,
 				1814B7801DF8455D003B3C65 /* GalleriesBatchFetcherSpec.swift in Sources */,

--- a/CreatubblesAPIClient/Sources/Core/APIClient.swift
+++ b/CreatubblesAPIClient/Sources/Core/APIClient.swift
@@ -455,6 +455,11 @@ open class APIClient: NSObject, CreationUploadServiceDelegate
         return galleryDAO.submitCreationToGallery(galleryIdentifier: galleryId, creationId: creationId, completion: completion)
     }
     
+    open func submitCreationToGalleries(creationId: String, galleryIdentifiers: Array<String>, completion: ErrorClosure?) -> RequestHandler
+    {
+        return galleryDAO.submitCreationToGalleries(creationId: creationId, galleryIdentifiers: galleryIdentifiers, completion: completion)
+    }
+
     //MARK: - Creation managment
     open func getCreation(creationId: String, completion: CreationClosure?) -> RequestHandler
     {

--- a/CreatubblesAPIClient/Sources/Core/Data/NewCreationData.swift
+++ b/CreatubblesAPIClient/Sources/Core/Data/NewCreationData.swift
@@ -45,7 +45,7 @@ open class NewCreationData: NSObject
     open var name: String? = nil
     open var reflectionText: String? = nil
     open var reflectionVideoUrl: String? = nil
-    open var galleryId: String? = nil
+    open var galleryIds: Array<String>? = nil
     open var creatorIds: Array<String>? = nil
     open var creationYear: Int? = nil
     open var creationMonth: Int? = nil
@@ -78,17 +78,14 @@ open class NewCreationData: NSObject
         self.name = creationDataEntity.name
         self.reflectionText = creationDataEntity.reflectionText
         self.reflectionVideoUrl = creationDataEntity.reflectionVideoUrl
-        self.galleryId = creationDataEntity.galleryId
-        self.creatorIds = Array<String>()
-        self.uploadExtension = creationDataEntity.uploadExtension
         
-        for creatorId in creationDataEntity.creatorIds
-        {
-            self.creatorIds!.append(creatorId.creatorIdString!)
-        }
+        self.uploadExtension = creationDataEntity.uploadExtension
         self.creationMonth = creationDataEntity.creationMonth.value
         self.creationYear = creationDataEntity.creationYear.value
         self.dataType = creationDataEntity.dataType
+        
+        self.creatorIds = creationDataEntity.creatorIds.flatMap({ $0.creatorIdString })
+        self.galleryIds = creationDataEntity.galleryIds.flatMap({ $0.galleryIdString })
         
         if(dataType.rawValue == 0)
         {

--- a/CreatubblesAPIClient/Sources/CreationUploadSession/CreationUploadSession.swift
+++ b/CreatubblesAPIClient/Sources/CreationUploadSession/CreationUploadSession.swift
@@ -80,7 +80,7 @@ class CreationUploadSession: NSObject, Cancelable
         self.state = creationUploadSessionEntity.state
         self.requestSender = requestSender
         self.imageFileName = creationUploadSessionEntity.imageFileName!
-        self.relativeFilePath = creationUploadSessionEntity.relativeImageFilePath!
+        self.relativeFilePath = creationUploadSessionEntity.relativeImageFilePath!        
         
         if let creationUploadEntity = creationUploadSessionEntity.creationUploadEntity
         {

--- a/CreatubblesAPIClient/Sources/DAO/GalleryDAO.swift
+++ b/CreatubblesAPIClient/Sources/DAO/GalleryDAO.swift
@@ -40,6 +40,12 @@ class GalleryDAO
         return requestSender.send(request, withResponseHandler: handler)
     }
     
+    open func submitCreationToGalleries(creationId: String, galleryIdentifiers: Array<String>, completion: ErrorClosure?) -> RequestHandler
+    {
+        let submitter = GallerySubmitter(requestSender: requestSender, creationId: creationId, galleryIdentifiers: galleryIdentifiers, completion: completion)
+        return submitter.submit()
+    }
+    
     func getGallery(galleryIdentifier galleryId: String, completion: GalleryClosure?) -> RequestHandler
     {
         let request = GalleriesRequest(galleryId: galleryId)

--- a/CreatubblesAPIClient/Sources/DAO/GallerySubmitter/GallerySubmitOperation.swift
+++ b/CreatubblesAPIClient/Sources/DAO/GallerySubmitter/GallerySubmitOperation.swift
@@ -1,0 +1,64 @@
+//
+//  GallerySubmitOperation.swift
+//  CreatubblesAPIClient
+//
+//  Copyright (c) 2016 Creatubbles Pte. Ltd.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import UIKit
+
+class GallerySubmitOperation: ConcurrentOperation
+{
+    private let requestSender: RequestSender
+    private let galleryId: String
+    private let creationId: String
+    private var requestHandler: RequestHandler?
+    
+    init(requestSender: RequestSender, galleryId: String, creationId: String, complete: OperationCompleteClosure?)
+    {
+        self.requestSender = requestSender
+        self.creationId = creationId
+        self.galleryId = galleryId
+        
+        super.init(complete: complete)
+    }
+    
+    override func main()
+    {
+        guard isCancelled == false else { return }
+        
+        let request = GallerySubmissionRequest(galleryId: galleryId, creationId: creationId)
+        let handler = GallerySubmissionResponseHandler()
+        {
+            [weak self](error) -> (Void) in
+            self?.finish(error)
+        }
+        
+        requestHandler = requestSender.send(request, withResponseHandler: handler)
+    }
+    
+    override func cancel()
+    {
+        requestHandler?.cancel()
+        super.cancel()
+    }
+
+}

--- a/CreatubblesAPIClient/Sources/DAO/GallerySubmitter/GallerySubmitter.swift
+++ b/CreatubblesAPIClient/Sources/DAO/GallerySubmitter/GallerySubmitter.swift
@@ -1,0 +1,96 @@
+//
+//  GallerySubmitter.swift
+//  CreatubblesAPIClient
+//
+//  Copyright (c) 2016 Creatubbles Pte. Ltd.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+class GallerySubmitter: Cancelable
+{
+    private let requestSender: RequestSender
+    private let creationId: String
+    private let galleryIdentifiers: Array<String>
+    private let completion: ErrorClosure?
+    
+    private var operationQueue: OperationQueue?
+    private var errors: Array<APIClientError>
+    
+    init(requestSender: RequestSender, creationId: String, galleryIdentifiers: Array<String>, completion: ErrorClosure?)
+    {
+        self.requestSender = requestSender
+        self.creationId = creationId
+        self.galleryIdentifiers = galleryIdentifiers
+        self.completion = completion
+        self.errors = Array<APIClientError>()
+    }
+    
+    func cancel()
+    {
+        operationQueue?.cancelAllOperations()
+    }
+    
+    func submit() -> RequestHandler
+    {
+        guard operationQueue == nil
+        else
+        {
+            assert(false) //Fetch should be called only once
+            return RequestHandler(object: self)
+        }
+        
+        operationQueue = OperationQueue()
+        operationQueue!.maxConcurrentOperationCount = 4
+        
+        let finishOperation = BlockOperation()
+        finishOperation.addExecutionBlock()
+        {
+            [unowned finishOperation, weak self] in
+            guard let strongSelf = self, !finishOperation.isCancelled else { return }
+            let error = strongSelf.errors.first
+            
+            DispatchQueue.main.async
+            {
+                [weak self] in
+                self?.completion?(error)
+            }
+        }
+        
+        galleryIdentifiers.forEach
+        {
+            (galleryId) in
+            let operation = GallerySubmitOperation(requestSender: requestSender, galleryId: galleryId, creationId: creationId)
+            {
+                [weak self](operation, error) in
+                guard operation is GallerySubmitOperation,
+                      let error = error as? APIClientError,
+                      let strongSelf = self
+                else { return }
+                strongSelf.errors.append(error)
+            }
+            
+            finishOperation.addDependency(operation)
+            operationQueue!.addOperation(operation)
+        }
+        operationQueue!.addOperation(finishOperation)
+        
+        return RequestHandler(object: self)
+    }
+}

--- a/CreatubblesAPIClient/Sources/Database/DatabaseService.swift
+++ b/CreatubblesAPIClient/Sources/Database/DatabaseService.swift
@@ -249,18 +249,25 @@ class DatabaseService: NSObject
         newCreationDataEntity.localIdentifier = newCreationData.localIdentifier
         newCreationDataEntity.reflectionText = newCreationData.reflectionText
         newCreationDataEntity.reflectionVideoUrl = newCreationData.reflectionVideoUrl
-        newCreationDataEntity.galleryId = newCreationData.galleryId
         newCreationDataEntity.dataTypeRaw.value = newCreationData.dataType.rawValue
         newCreationDataEntity.uploadExtensionRaw = newCreationData.uploadExtension.stringValue
         
-        if let _ = newCreationData.creatorIds
+        newCreationData.creatorIds?.forEach()
         {
-            for creatorId in newCreationData.creatorIds!
-            {
-                let creatorIdEntity = CreatorIdString()
-                creatorIdEntity.creatorIdString = creatorId
-                newCreationDataEntity.creatorIds.append(creatorIdEntity)
-            }
+            creatorIdentifier in
+            
+            let idEntity = CreatorIdString()
+            idEntity.creatorIdString = creatorIdentifier
+            newCreationDataEntity.creatorIds.append(idEntity)
+        }
+        
+        newCreationData.galleryIds?.forEach()
+        {
+            galleryIdentifier in
+            
+            let idEntity = GalleryIdString()
+            idEntity.galleryIdString = galleryIdentifier
+            newCreationDataEntity.galleryIds.append(idEntity)
         }
         
         newCreationDataEntity.creationYear.value = newCreationData.creationYear

--- a/CreatubblesAPIClient/Sources/Database/Entity/NewCreationDataEntity.swift
+++ b/CreatubblesAPIClient/Sources/Database/Entity/NewCreationDataEntity.swift
@@ -30,6 +30,11 @@ class CreatorIdString: Object
     dynamic var creatorIdString: String?
 }
 
+class GalleryIdString: Object
+{
+    dynamic var galleryIdString: String?
+}
+
 class NewCreationDataEntity: Object
 {
     dynamic var name: String?
@@ -39,7 +44,10 @@ class NewCreationDataEntity: Object
     dynamic var reflectionVideoUrl: String?
     dynamic var galleryId: String?
     dynamic var uploadExtensionRaw: String?
+    
     var creatorIds = List<CreatorIdString>()
+    var galleryIds = List<GalleryIdString>()
+    
     var creationYear = RealmOptional<Int>()
     var creationMonth = RealmOptional<Int>()
     

--- a/CreatubblesAPIClientTests/Spec/GallerySubmitter/GallerySubmitterSpec.swift
+++ b/CreatubblesAPIClientTests/Spec/GallerySubmitter/GallerySubmitterSpec.swift
@@ -1,0 +1,67 @@
+//
+//  CreationsBatchFetcherSpec.swift
+//  CreatubblesAPIClient
+//
+//  Copyright (c) 2016 Creatubbles Pte. Ltd.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Quick
+import Nimble
+@testable import CreatubblesAPIClient
+
+class GallerySubmitterSpec: QuickSpec
+{
+    override func spec()
+    {
+        describe("GallerySubmitter")
+        {
+            it("Should batch fetch creations using operation client")
+            {
+                guard TestConfiguration.shoulTestBatchFetchers,
+                      let creationIdentifier = TestConfiguration.testCreationIdentifier,
+                      let galleryIdentifiers = TestConfiguration.testGalleryIdentifiers
+                else { return }
+                
+                let sender = TestComponentsFactory.requestSender
+                var submitter: GallerySubmitter!
+                
+                waitUntil(timeout: 200)
+                {
+                    done in
+                    sender.login(TestConfiguration.username, password: TestConfiguration.password)
+                    {
+                        (error) -> (Void) in
+                        expect(error).to(beNil())
+                        expect(sender.isLoggedIn()).to(beTrue())
+                        
+                        submitter = GallerySubmitter(requestSender: sender, creationId: creationIdentifier, galleryIdentifiers: galleryIdentifiers)
+                        {
+                            (error) -> (Void) in
+                            expect(error).to(beNil())
+                            done()
+                        }
+                        submitter.submit()
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
JIRA task:
https://nomtek.atlassian.net/browse/CRI-682

Changes:
- Added `GallerySubmitter` which use `OperationQueue` to upload Creation to multiple galleries in single APIClient method.
- Change `CreationUploadSession` to use `GallerySubmitter`. This forced me to change fields in `NewCreationData` and `NewCreationDataEntity`.