### PR TITLE
[CRI-1092] Removed „Explorer” part from files’ headers.

### DIFF
--- a/CreatubblesAPIClient/Sources/Utils/ConcurrentOperation.swift
+++ b/CreatubblesAPIClient/Sources/Utils/ConcurrentOperation.swift
@@ -1,6 +1,6 @@
 //
 //  ConcurrentOperation.swift
-//  Creatubbles Explorer
+//  CreatubblesAPIClient
 //
 //  Copyright (c) 2017 Creatubbles Pte. Ltd.
 //


### PR DESCRIPTION
JIRA: https://nomtek.atlassian.net/browse/CRI-1092

Creatubbles app's related PR: 
https://github.com/creatubbles/ctb-ios-explorer/pull/738