### PR TITLE
[CRI-523] Changed ResponseData's init to public

### DIFF
--- a/CreatubblesAPIClient/Sources/Core/APIClient.swift
+++ b/CreatubblesAPIClient/Sources/Core/APIClient.swift
@@ -70,7 +70,7 @@ open class ResponseData<T> {
     open let pagingInfo: PagingInfo?
     open let error: APIClientError?
     
-    init(objects: Array<T>?, rejectedObjects: Array<T>?, pagingInfo: PagingInfo?, error: APIClientError?) {
+    public init(objects: Array<T>?, rejectedObjects: Array<T>?, pagingInfo: PagingInfo?, error: APIClientError?) {
         self.objects = objects
         self.rejectedObjects = rejectedObjects
         self.pagingInfo = pagingInfo


### PR DESCRIPTION
jira: https://nomtek.atlassian.net/browse/CRI-523

A very minor change - if init isn't public, it can't be accessed in private APIClient.