### PR TITLE
Add missing 'includesSubmittingToGallery' method to upload session

### DIFF
--- a/CreatubblesAPIClient/Sources/CreationUploadSession/CreationUploadSessionPublicData.swift
+++ b/CreatubblesAPIClient/Sources/CreationUploadSession/CreationUploadSessionPublicData.swift
@@ -59,4 +59,8 @@ open class CreationUploadSessionPublicData: NSObject {
             status = .inProgress
         }
     }
+
+    open func includesSubmittingToGallery(withIdentifier galleryIdentifier: String) -> Bool {
+        return creationData.galleryIds?.contains(galleryIdentifier) ?? false
+    }
 }


### PR DESCRIPTION
There's no Trello for this PR. 'includesSubmittingToGallery' was added to an API client file in the app project and is missing after updating API client pod. This PR adds the method to the API client itself.