### PR TITLE
[845] Fix invalid filter parameter in fetch my galleries request

### DIFF
--- a/CreatubblesAPIClient/Sources/Requests/Gallery/MyGalleriesRequest.swift
+++ b/CreatubblesAPIClient/Sources/Requests/Gallery/MyGalleriesRequest.swift
@@ -57,8 +57,8 @@ class MyGalleriesRequest: Request {
         
         if let filter = filter {
             switch filter {
-                case .owned: params["gallery_filter"] = "only_owned" as AnyObject?
-                case .shared: params["gallery_filter"] = "only_shared" as AnyObject?
+                case .owned: params["filter[only_owned]"] = true as AnyObject?
+                case .shared: params["filter[only_shared]"] = true as AnyObject?
             }
         }
         

--- a/CreatubblesAPIClientUnitTests/Spec/Gallery/MyGalleriesRequestSpec.swift
+++ b/CreatubblesAPIClientUnitTests/Spec/Gallery/MyGalleriesRequestSpec.swift
@@ -40,22 +40,23 @@ class MyGalleriesRequestSpec: QuickSpec {
                 expect(request.endpoint) == "users/me/galleries"
             }
 
-            it("Shouldn't have gallery_filter parameter for all galleries") {
+            it("Shouldn't have filter parameter for all galleries") {
                 let request = MyGalleriesRequest(page: 1, perPage: 20, filter: .none)
                 let params = request.parameters
-                expect(params["gallery_filter"] as? String).to(beNil())
+                expect(params["filter[only_owned]"] as? Bool).to(beNil())
+                expect(params["filter[only_shared]"] as? Bool).to(beNil())
             }
 
-            it("Shouldn have gallery_filter parameter for shared galleries") {
+            it("Should have filter[only_owned] parameter for owned galleries") {
                 let request = MyGalleriesRequest(page: 1, perPage: 20, filter: .owned)
                 let params = request.parameters
-                expect(params["gallery_filter"] as? String) == "only_owned"
+                expect(params["filter[only_owned]"] as? Bool).to(beTrue())
             }
 
-            it("Shouldn't have gallery_filter parameter for owned galleries") {
+            it("Should have filter[only_shared] parameter for shared galleries") {
                 let request = MyGalleriesRequest(page: 1, perPage: 20, filter: .shared)
                 let params = request.parameters
-                expect(params["gallery_filter"] as? String) == "only_shared"
+                expect(params["filter[only_shared]"] as? Bool).to(beTrue())
             }
         }
     }


### PR DESCRIPTION
Trello: https://trello.com/c/aIa4R96t/845-child-cant-select-its-teachers-gallery-during-upload-flow

We've used the wrong filters for owned and shared galleries (`gallery_filter=only_owned/only_shared` instead of `filter[only_owned/only_shared]=true`): https://developers.creatubbles.com/api/#list-galleries.

Examples:
No filter (returns owned + shared):
`curl -H "Host: api.staging.creatubbles.com" -H "Cookie: returning_user=1" -H "X-Device-Type: phone" -H "Accept: application/json" -H "User-Agent: Creatubbles Staging/1.8.2 (com.creatubbles.explorer.staging; build:1; iOS 11.1.0)" -H "Authorization: Bearer 51c65bf9419ddd0781a419a75a6f4639f365097a1cd94af75df64d77393d0d2e" -H "Accept-Language: en-US;q=1.0, ja-US;q=0.9, it-US;q=0.8, en;q=0.7, pl-PL;q=0.6" --compressed https://api.staging.creatubbles.com/v2/users/CEbarqan/galleries?page=1&per_page=20`

Previous `owned` filter (returns owned + shared):
`curl -H "Host: api.staging.creatubbles.com" -H "Cookie: returning_user=1" -H "X-Device-Type: phone" -H "Accept: application/json" -H "User-Agent: Creatubbles Staging/1.8.2 (com.creatubbles.explorer.staging; build:1; iOS 11.1.0)" -H "Authorization: Bearer 51c65bf9419ddd0781a419a75a6f4639f365097a1cd94af75df64d77393d0d2e" -H "Accept-Language: en-US;q=1.0, ja-US;q=0.9, it-US;q=0.8, en;q=0.7, pl-PL;q=0.6" --compressed https://api.staging.creatubbles.com/v2/users/CEbarqan/galleries?page=1&per_page=20&gallery_filter=only_owned`

New `owned` filter (returns owned):
`curl -H "Host: api.staging.creatubbles.com" -H "Cookie: returning_user=1" -H "X-Device-Type: phone" -H "Accept: application/json" -H "User-Agent: Creatubbles Staging/1.8.2 (com.creatubbles.explorer.staging; build:1; iOS 11.1.0)" -H "Authorization: Bearer 51c65bf9419ddd0781a419a75a6f4639f365097a1cd94af75df64d77393d0d2e" -H "Accept-Language: en-US;q=1.0, ja-US;q=0.9, it-US;q=0.8, en;q=0.7, pl-PL;q=0.6" --compressed https://api.staging.creatubbles.com/v2/users/CEbarqan/galleries?page=1&per_page=20&filter%5Bonly_owned%5D=true`