### PR TITLE
Make the CommentsDAO requestSender public so that the Creatubbles core project builds on develop

### DIFF
--- a/CreatubblesAPIClient/Sources/DAO/CommentsDAO.swift
+++ b/CreatubblesAPIClient/Sources/DAO/CommentsDAO.swift
@@ -26,7 +26,7 @@
 import UIKit
 
 open class CommentsDAO: NSObject, APIClientDAO {
-    fileprivate let requestSender: RequestSender
+    public let requestSender: RequestSender
 
     public required init(dependencies: DAODependencies) {
         self.requestSender = dependencies.requestSender


### PR DESCRIPTION
No Trello card. This is needed so that the Creatubbles core on develop builds with the latest API client.