### PR TITLE
[781] Ensure upload completion is called when creation asset processing is finished and handle the case when processing fails

### DIFF
--- a/CreatubblesAPIClient/Sources/Core/APIClient.swift
+++ b/CreatubblesAPIClient/Sources/Core/APIClient.swift
@@ -491,6 +491,10 @@ open class APIClient: NSObject, CreationUploadServiceDelegate {
         creationUploadService.refreshCreationStatusInUploadSession(creationId: creationId)
     }
 
+    open func notifyCreationProcessingFailed(creationId: String) {
+        creationUploadService.notifyCreationProcessingFailed(creationId: creationId)
+    }
+
     // MARK: - Creation flow
     open func newCreation(data creationData: NewCreationData, localDataPreparationCompletion: ((_ error: Error?) -> Void)?, completion: CreationClosure?) -> CreationUploadSessionPublicData? {
         return creationUploadService.uploadCreation(data: creationData, localDataPreparationCompletion: localDataPreparationCompletion, completion: completion)

--- a/CreatubblesAPIClient/Sources/CreationUploadSession/CreationUploadService.swift
+++ b/CreatubblesAPIClient/Sources/CreationUploadSession/CreationUploadService.swift
@@ -185,6 +185,11 @@ class CreationUploadService: CreationUploadSessionDelegate {
         sessions.forEach({ $0.refreshCreation(completion: nil) })
     }
 
+    open func notifyCreationProcessingFailed(creationId: String) {
+        let sessions = uploadSessions.filter({ $0.creation?.identifier == creationId })
+        sessions.forEach({ $0.setCreationProcessingFailed() })
+    }
+
     // MARK: - CreationUploadSessionDelegate
     func creationUploadSessionChangedState(_ creationUploadSession: CreationUploadSession) {
         databaseDAO.saveCreationUploadSessionToDatabase(creationUploadSession)


### PR DESCRIPTION
Trello: https://trello.com/c/f3TknDQ5/781-app-should-not-crash-when-uploading-multiple-videos